### PR TITLE
Fix feature/category links

### DIFF
--- a/components/categories-card.tsx
+++ b/components/categories-card.tsx
@@ -8,7 +8,7 @@ interface CategoryCardProps {
 export default function CategoryCard({ category }: CategoryCardProps) {
   return (
     <Link
-      href={`/customer/categories/${category.slug}`}
+      href={`/customer/collection?category=${category.slug}`}
       className="relative flex justify-center items-center overflow-hidden border border-(--color-cream) hover:shadow-lg/10 transition bg-cover bg-center aspect-4/3 "
       style={{
         backgroundImage: `url(${category.image})`,


### PR DESCRIPTION
Change routing in category-card. Now using query params routing to product-page/*category* instead of dynamic category page.